### PR TITLE
Fix Track parsing if MUSDB is in WAV-Format

### DIFF
--- a/musdb/audio_classes.py
+++ b/musdb/audio_classes.py
@@ -157,7 +157,7 @@ class Track(object):
         subset=None,
         path=None
     ):
-        self.name = os.path.splitext(name)[0].split('.stem')[0]
+        self.name = name.split('.stem.mp4')[0]
         try:
             split_name = name.split(' - ')
             self.artist = split_name[0]


### PR DESCRIPTION
@faroit I noticed that there is a problem with the `Track` class if `name` contains a `.` and the data is in WAV-Format.

For example, `M.E.R.C. Music - Knockout`:
```
>>> import musdb
>>> musdb.Track(name='M.E.R.C. Music - Knockout')

M.E.R.C.
```

After the fix, one obtains the following:
```
>>> import musdb
>>> musdb.Track(name='M.E.R.C. Music - Knockout')

M.E.R.C. Music - Knockout
```