### PR TITLE
Update index.rst to include link to SigSep 2018 paper

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,6 @@ Contents:
 References
 ~~~~~~~~~~
 
-If you use this package, please reference the following paper
+If you use this package, please reference the following paper: https://arxiv.org/abs/1804.06267
 
 .. code:: tex


### PR DESCRIPTION
Unless I'm missing something, I believe this page should link the SigSec 2018 paper?