### PR TITLE
remove useless and confusing code.

### DIFF
--- a/musdb/audio_classes.py
+++ b/musdb/audio_classes.py
@@ -269,7 +269,7 @@ class Target(Track):
 
         mixes audio for targets on the fly
         """
-        mix_list = []*len(self.sources)
+        mix_list = []
         for source in self.sources:
             audio = source.audio
             if audio is not None:


### PR DESCRIPTION
It makes no sense for `[]*a_number`.

`[]*a_number` is still an empty list and it does not pre-allocate space.