### PR TITLE
Remove an unused and confusing option.

### DIFF
--- a/musdb/tools.py
+++ b/musdb/tools.py
@@ -31,12 +31,6 @@ def musdb_convert(inargs=None):
         '--extension', type=str, default='.wav', 
     )
 
-    parser.add_argument(
-        '--hop',
-        type=int, default=1024,
-        help='hop size in samples, defaults to `1024`'
-    )
-
     args = parser.parse_args(inargs)
 
     mus = DB(root=args.musdb_root, download=args.download)


### PR DESCRIPTION
The option `hop` is not used but is shown in the help message, which is quite annoying and confusing.