### PR TITLE
[F] Fix path check

### DIFF
--- a/musdb/audio_classes.py
+++ b/musdb/audio_classes.py
@@ -94,7 +94,7 @@ class Track(object):
     ):
         """array_like: [shape=(num_samples, num_channels)]
         """
-        if os.path.exists(self.path):
+        if os.path.exists(path):
             if self.is_wav:
                 stem_id = 0
             audio, rate = stempeg.read_stems(

--- a/musdb/audio_classes.py
+++ b/musdb/audio_classes.py
@@ -94,7 +94,7 @@ class Track(object):
     ):
         """array_like: [shape=(num_samples, num_channels)]
         """
-        if os.path.exists(path):
+        if os.path.exists(self.path):
             if self.is_wav:
                 stem_id = 0
             audio, rate = stempeg.read_stems(
@@ -111,7 +111,7 @@ class Track(object):
         else:
             self._rate = None
             self._audio = None
-            raise ValueError("Oops! %s cannot be loaded" % path)
+            raise ValueError("Oops! File %s does not exist." % self.path)
 
     def __repr__(self):
         return "%s" % (self.path)


### PR DESCRIPTION
The original code loads audio from `path` (passed through function arguments) while it checks the existence of `self.path` (passed during init). This PR fixes that.

Specifically, I ran into a problem when trying to train UMX that it says ".../vocals.wav cannot be loaded" even though the file exists (since the path check is checking for "mixture.wav" which isn't used.

![image](https://github.com/user-attachments/assets/26cf799e-781d-4a25-ba04-014fc4dc1d48)
